### PR TITLE
114 bug initial color in shapes is always red

### DIFF
--- a/glse/shapes_tab.py
+++ b/glse/shapes_tab.py
@@ -90,7 +90,7 @@ def create_polygon_tab(window):
     initial_color = (
         window.params["Polygon"]["_fill_color"]
         if window.params["Polygon"]["_fill_color"] is not None
-        else "C1"
+        else "grey"
     )
     color = ColorPickerWidget(
         window,

--- a/glse/shapes_tab.py
+++ b/glse/shapes_tab.py
@@ -87,12 +87,18 @@ def create_polygon_tab(window):
     layout.addWidget(line_style)
 
     # create fill color picker
+    initial_color = (
+        window.params["Polygon"]["_fill_color"]
+        if window.params["Polygon"]["_fill_color"] is not None
+        else "C1"
+    )
     color = ColorPickerWidget(
         window,
         "Fill Color",
         param_ids=[["Polygon", "Circle", "Rectangle"], ["_fill_color"]],
+        initial_color=initial_color,
         activated_on_init=(
-            False if window.params["Polygon"]["_fill_color"] == "" else True
+            False if window.params["Polygon"]["_fill_color"] is None else True
         ),
     )
     color_picker_widget = Activator(
@@ -105,12 +111,18 @@ def create_polygon_tab(window):
     layout.addWidget(color_picker_widget)
 
     # create edge color picker
+    initial_color = (
+        window.params["Polygon"]["_edge_color"]
+        if window.params["Polygon"]["_edge_color"] is not None
+        else "black"
+    )
     edge_color = ColorPickerWidget(
         window,
         "Edge Color",
         param_ids=[["Polygon", "Circle", "Rectangle"], ["_edge_color"]],
+        initial_color=initial_color,
         activated_on_init=(
-            False if window.params["Polygon"]["_edge_color"] == "" else True
+            False if window.params["Polygon"]["_edge_color"] is None else True
         ),
     )
     edge_color_picker_widget = Activator(


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/en/latest/contributing.html#guideline-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->
Updated fill and edge color pickers in shapes_tab to add initial color
Closes issue #114.


## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [N/A] Docstrings are complete
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [N/A] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/en/latest/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [N/A] If your changes modify the UI or add/change functionality, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/en/latest/contributing.html#guideline-for-submitting-a-pull-request).
- [x] Links to the related issue (#....)
